### PR TITLE
Improvements for OpenWeather test automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+#node_modules
 node_modules/
 
 # Test information

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,5 +5,6 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+    baseUrl: 'https://openweathermap.org'
   },
-});
+})

--- a/cypress/e2e/TestTask/LogIn_Test.cy.js
+++ b/cypress/e2e/TestTask/LogIn_Test.cy.js
@@ -1,3 +1,4 @@
+import selectors from '..//..//support/selectors.json';
 describe('User Login', () => {
 
   beforeEach(() => {
@@ -9,18 +10,18 @@ describe('User Login', () => {
   // Loading user data 
     const user = Cypress.env("user")
     
-    cy.get('.user-li > a').click()
+    cy.get(selectors.loginPage.loginButton).click()
   // Enter credentials
-    cy.get('#user_email').type(user.email)
-    cy.get('#user_password').type(user.password)
+    cy.get(selectors.loginPage.emailInput).type(user.email)
+    cy.get(selectors.loginPage.passwordInput).type(user.password)
 
   // Submit the login form
-    cy.get('.new_user > .btn').click()
+    cy.get(selectors.loginPage.submitButton).click()
   
   // Redirecting to the homepage upon successful login
     cy.url('').should('include', '/home')
 
   // Assert that the user profile icon is visible
-    cy.get('.panel-body').should('be.visible')
+    cy.get(selectors.dashboardPage.userProfileIcon).should('be.visible')
   })
 })

--- a/cypress/e2e/TestTask/LogIn_Test.cy.js
+++ b/cypress/e2e/TestTask/LogIn_Test.cy.js
@@ -1,27 +1,26 @@
 describe('User Login', () => {
 
   beforeEach(() => {
-   // Loading user data 
-    const user = Cypress.env("user")
-    
-  // LOG IN
   // Navigate to the OpenWeather login page.
-    cy.visit('https://openweathermap.org');
-
-    cy.get('.user-li > a').click();
-  // Enter credentials
-    cy.get('#user_email').type(user.email);
-    cy.get('#user_password').type(user.password);
-
-  // Submit the login form
-    cy.get('.new_user > .btn').click();
-  });
+    cy.visit('https://openweathermap.org') })
 
   it('should log in with valid credentials', () => {
-    // Redirecting to the homepage upon successful login
+  // LOG IN
+  // Loading user data 
+    const user = Cypress.env("user")
+    
+    cy.get('.user-li > a').click()
+  // Enter credentials
+    cy.get('#user_email').type(user.email)
+    cy.get('#user_password').type(user.password)
+
+  // Submit the login form
+    cy.get('.new_user > .btn').click()
+  
+  // Redirecting to the homepage upon successful login
     cy.url('').should('include', '/home')
 
-    // Assert that the user profile icon is visible
+  // Assert that the user profile icon is visible
     cy.get('.panel-body').should('be.visible')
-  });
-});
+  })
+})

--- a/cypress/e2e/TestTask/LogIn_Test.cy.js
+++ b/cypress/e2e/TestTask/LogIn_Test.cy.js
@@ -2,7 +2,7 @@ describe('User Login', () => {
 
   beforeEach(() => {
   // Navigate to the OpenWeather login page.
-    cy.visit('https://openweathermap.org') })
+    cy.visit('') })
 
   it('should log in with valid credentials', () => {
   // LOG IN

--- a/cypress/e2e/TestTask/LogOutTest.cy.js
+++ b/cypress/e2e/TestTask/LogOutTest.cy.js
@@ -4,7 +4,7 @@ describe('User LogOut', () => {
    // Loading user data 
     const user = Cypress.env("user")
     
-  // LOG  IN
+  // LOG IN TO THE SITE
   // Navigate to the OpenWeather login page.
     cy.visit('https://openweathermap.org')
 

--- a/cypress/e2e/TestTask/LogOutTest.cy.js
+++ b/cypress/e2e/TestTask/LogOutTest.cy.js
@@ -1,4 +1,4 @@
-describe('User Login', () => {
+describe('User LogOut', () => {
 
   beforeEach(() => {
    // Loading user data 
@@ -17,7 +17,7 @@ describe('User Login', () => {
     cy.get('.new_user > .btn').click()
   })
 
-  it('Verify the presence of key elements', () => {
+  it('LogOut test', () => {
   //LOG OUT
     cy.get('.inner-user-container').wait(5000).click()
     cy.get(':nth-child(5) > .logout').click()

--- a/cypress/e2e/TestTask/LogOutTest.cy.js
+++ b/cypress/e2e/TestTask/LogOutTest.cy.js
@@ -6,7 +6,7 @@ describe('User LogOut', () => {
     
   // LOG IN TO THE SITE
   // Navigate to the OpenWeather login page.
-    cy.visit('https://openweathermap.org')
+    cy.visit('')
 
     cy.get('.user-li > a').click()
   // Enter credentials

--- a/cypress/e2e/TestTask/LogOutTest.cy.js
+++ b/cypress/e2e/TestTask/LogOutTest.cy.js
@@ -4,7 +4,7 @@ describe('User Login', () => {
    // Loading user data 
     const user = Cypress.env("user")
     
-  // LOG IN
+  // LOG  IN
   // Navigate to the OpenWeather login page.
     cy.visit('https://openweathermap.org')
 

--- a/cypress/e2e/TestTask/LogOutTest.cy.js
+++ b/cypress/e2e/TestTask/LogOutTest.cy.js
@@ -1,3 +1,5 @@
+import selectors from '..//..//support/selectors.json';
+
 describe('User LogOut', () => {
 
   beforeEach(() => {
@@ -8,18 +10,18 @@ describe('User LogOut', () => {
   // Navigate to the OpenWeather login page.
     cy.visit('')
 
-    cy.get('.user-li > a').click()
+    cy.get(selectors.loginPage.loginButton).click()
   // Enter credentials
-    cy.get('#user_email').type(user.email)
-    cy.get('#user_password').type(user.password)
+    cy.get(selectors.loginPage.emailInput).type(user.email)
+    cy.get(selectors.loginPage.passwordInput).type(user.password)
 
   // Submit the login form
-    cy.get('.new_user > .btn').click()
+    cy.get(selectors.loginPage.submitButton).click()
   })
 
   it('LogOut test', () => {
   //LOG OUT
-    cy.get('.inner-user-container').wait(5000).click()
-    cy.get(':nth-child(5) > .logout').click()
+    cy.get(selectors.dashboardPage.logoutMenuButton).wait(5000).click()
+    cy.get(selectors.dashboardPage.logoutButton).click()
       })
 })

--- a/cypress/e2e/TestTask/Page Elements.cy.js
+++ b/cypress/e2e/TestTask/Page Elements.cy.js
@@ -1,3 +1,6 @@
+import selectors from '..//..//support/selectors.json';
+
+
 describe('Verification of Page Elements', () => {
 
   const user = Cypress.env("user")
@@ -10,47 +13,45 @@ describe('Verification of Page Elements', () => {
   // Navigate to the OpenWeather login page.
     cy.visit('')
 
-    cy.get('.user-li > a').click()
+    cy.get(selectors.loginPage.loginButton).click()
   // Enter credentials
-    cy.get('#user_email').type(user.email)
-    cy.get('#user_password').type(user.password)
+    cy.get(selectors.loginPage.emailInput).type(user.email)
+    cy.get(selectors.loginPage.passwordInput).type(user.password)
 
   // Submit the login form
-    cy.get('.new_user > .btn').click()
+    cy.get(selectors.loginPage.submitButton).click()
   })
 
   it('Verify the presence of key elements', () => {
 
-
   // The search bar for finding weather in different cities.
-    cy.get('#desktop-menu > form')
+    cy.get(selectors.commonElements.searchForm).wait(3000)
     .should('be.exist')
     .should('be.visible')
 
-    cy.get('.logo > a > img').click();
-    cy.get('#desktop-menu > form > [name="q"]')
+    cy.get(selectors.commonElements.logo).click();
+    cy.get(selectors.commonElements.searchInput)
     .type(`${user.city}{enter}`)
 
-
   //The current weather section.
-     cy.get('.headline')
+     cy.get(selectors.weatherPage.headline)
     .should('be.exist')
     .should('be.visible')
     .and('contain.text', 'Weather in your city')
 
-    cy.get('body > main > div:nth-child(7) > div > div')
+    cy.get(selectors.weatherPage.weatherInfo)
     .should('be.exist')
     .should('be.visible')
 
-    cy.get('tbody > :nth-child(1) > :nth-child(2) > :nth-child(1) > a')
+    cy.get(selectors.weatherPage.firstWeatherLink)
     .click()
       
   //The forecast section.
-    cy.get('#weather-widget > .section-content')
+    cy.get(selectors.weatherPage.forecastSection)
     .should('be.exist')
     .should('be.visible')
 
-    cy.get('.grid-5-4 > :nth-child(1) > .mobile-padding')
+    cy.get(selectors.weatherPage.hourlyForecastText)
     .should('be.exist')
     .should('be.visible')
     .and('have.text', 'Hourly forecast')

--- a/cypress/e2e/TestTask/Page Elements.cy.js
+++ b/cypress/e2e/TestTask/Page Elements.cy.js
@@ -8,7 +8,7 @@ describe('Verification of Page Elements', () => {
     
   // LOG IN
   // Navigate to the OpenWeather login page.
-    cy.visit('https://openweathermap.org')
+    cy.visit('')
 
     cy.get('.user-li > a').click()
   // Enter credentials

--- a/cypress/e2e/TestTask/Page Elements.cy.js
+++ b/cypress/e2e/TestTask/Page Elements.cy.js
@@ -21,7 +21,7 @@ describe('Verification of Page Elements', () => {
 
   it('Verify the presence of key elements', () => {
 
-// The search bar for finding weather in different cities.
+  // The search bar for finding weather in different cities.
     cy.get('#desktop-menu > form')
     .should('be.exist')
     .should('be.visible')
@@ -30,7 +30,7 @@ describe('Verification of Page Elements', () => {
     cy.get('#desktop-menu > form > [name="q"]')
     .type(`${user.city}{enter}`)
 
-      //The current weather section.
+  //The current weather section.
      cy.get('.headline')
     .should('be.exist')
     .should('be.visible')

--- a/cypress/e2e/TestTask/Page Elements.cy.js
+++ b/cypress/e2e/TestTask/Page Elements.cy.js
@@ -22,35 +22,35 @@ describe('Verification of Page Elements', () => {
   it('Verify the presence of key elements', () => {
 
 // The search bar for finding weather in different cities.
-  cy.get('#desktop-menu > form')
-  .should('be.exist')
-  .should('be.visible')
+    cy.get('#desktop-menu > form')
+    .should('be.exist')
+    .should('be.visible')
 
-  cy.get('.logo > a > img').click();
-  cy.get('#desktop-menu > form > [name="q"]')
-  .type(`${user.city}{enter}`)
+    cy.get('.logo > a > img').click();
+    cy.get('#desktop-menu > form > [name="q"]')
+    .type(`${user.city}{enter}`)
 
       //The current weather section.
-  cy.get('.headline')
-  .should('be.exist')
-      .should('be.visible')
-      .and('contain.text', 'Weather in your city')
+     cy.get('.headline')
+    .should('be.exist')
+    .should('be.visible')
+    .and('contain.text', 'Weather in your city')
 
-      cy.get('body > main > div:nth-child(7) > div > div')
-      .should('be.exist')
-      .should('be.visible')
+    cy.get('body > main > div:nth-child(7) > div > div')
+    .should('be.exist')
+    .should('be.visible')
 
-      cy.get('tbody > :nth-child(1) > :nth-child(2) > :nth-child(1) > a')
-      .click()
+    cy.get('tbody > :nth-child(1) > :nth-child(2) > :nth-child(1) > a')
+    .click()
       
-      //The forecast section.
-      cy.get('#weather-widget > .section-content')
-      .should('be.exist')
-      .should('be.visible')
+  //The forecast section.
+    cy.get('#weather-widget > .section-content')
+    .should('be.exist')
+    .should('be.visible')
 
-      cy.get('.grid-5-4 > :nth-child(1) > .mobile-padding')
-      .should('be.exist')
-      .should('be.visible')
-      .and('have.text', 'Hourly forecast')
-      })
+    cy.get('.grid-5-4 > :nth-child(1) > .mobile-padding')
+    .should('be.exist')
+    .should('be.visible')
+    .and('have.text', 'Hourly forecast')
+    })
 })

--- a/cypress/e2e/UserFlow/LogIn_Test.cy.js
+++ b/cypress/e2e/UserFlow/LogIn_Test.cy.js
@@ -1,4 +1,4 @@
-import selectors from '..//..//support/selectors.json';
+import selectors from '../../support/selectors.json';
 describe('User Login', () => {
 
   beforeEach(() => {

--- a/cypress/e2e/UserFlow/LogOutTest.cy.js
+++ b/cypress/e2e/UserFlow/LogOutTest.cy.js
@@ -1,4 +1,4 @@
-import selectors from '..//..//support/selectors.json';
+import selectors from '../../support/selectors.json';
 
 describe('User LogOut', () => {
 

--- a/cypress/e2e/UserFlow/Page Elements.cy.js
+++ b/cypress/e2e/UserFlow/Page Elements.cy.js
@@ -1,4 +1,4 @@
-import selectors from '..//..//support/selectors.json';
+import selectors from '../../support/selectors.json';
 
 
 describe('Verification of Page Elements', () => {

--- a/cypress/support/selectors.json
+++ b/cypress/support/selectors.json
@@ -1,0 +1,26 @@
+{
+    "loginPage": {
+      "loginButton": ".user-li > a",
+      "emailInput": "#user_email",
+      "passwordInput": "#user_password",
+      "submitButton": ".new_user > .btn"
+    },
+    "dashboardPage": {
+      "userProfileIcon": ".panel-body",
+      "logoutMenuButton": ".inner-user-container",
+      "logoutButton": ":nth-child(5) > .logout"
+    },
+    "commonElements": {
+      "searchForm": "#desktop-menu > form",
+      "searchInput": "#desktop-menu > form > [name='q']",
+      "logo": ".logo > a > img"
+    },
+    "weatherPage": {
+      "headline": ".headline",
+      "weatherInfo": "body > main > div:nth-child(7) > div > div",
+      "firstWeatherLink": "tbody > :nth-child(1) > :nth-child(2) > :nth-child(1) > a",
+      "forecastSection": "#weather-widget > .section-content",
+      "hourlyForecastText": ".grid-5-4 > :nth-child(1) > .mobile-padding"
+    }
+  }
+  


### PR DESCRIPTION
Improve the test project set up by adding the following:
1. in cypress.config.js file, add the settings for baseUrl; put the website link as baseUrl
2. Move selectors to the support folder and import them as objects to the files with tests (specs)
3. Rename e2e/TestTask to something else, that is project-specific and displays the functionality that is tested, like authentication, general, etc.